### PR TITLE
feat: add allowExpressions true to no useless fragment rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-reearth",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "index.js",
   "repository": "https://github.com/reearth/eslint-config-reearth.git",
   "author": "rot1024 <aayhrot@gmail.com>",

--- a/react.js
+++ b/react.js
@@ -8,11 +8,19 @@ module.exports = {
     "react/prop-types": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "react/jsx-no-useless-fragment": "warn",
-    "react/self-closing-comp": ["warn", {
-      "component": true,
-      "html": true
-    }]
+    "react/jsx-no-useless-fragment": [
+      "warn",
+      {
+        allowExpressions: true,
+      },
+    ],
+    "react/self-closing-comp": [
+      "warn",
+      {
+        component: true,
+        html: true,
+      },
+    ],
   },
   settings: {
     react: {


### PR DESCRIPTION
Adding this because its useful to be able to pass props in to a fragment, like:
```
{ifSomeProp ? <>{children</> : null}
```